### PR TITLE
Added Build CI

### DIFF
--- a/.github/workflows/autoprime-build.yml
+++ b/.github/workflows/autoprime-build.yml
@@ -1,0 +1,26 @@
+name: Auto Prime Build
+
+on:
+  push:
+    branches: [ "AutoPrime-main" ]
+  pull_request:
+    branches: [ "AutoPrime-main" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: set up JDK 11
+      uses: actions/setup-java@v3
+      with:
+        java-version: '11'
+        distribution: 'temurin'
+        cache: gradle
+
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+    - name: Build with Gradle
+      run: ./gradlew build -x lint

--- a/.github/workflows/jankbot-build.yml
+++ b/.github/workflows/jankbot-build.yml
@@ -1,0 +1,27 @@
+name: Jankbot Build
+
+on:
+  push:
+    branches: [ "Jankbot-main" ]
+  pull_request:
+    branches: [ "Jankbot-main" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: set up JDK 11
+      uses: actions/setup-java@v3
+      with:
+        java-version: '11'
+        distribution: 'temurin'
+        cache: gradle
+
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+      
+    - name: Build with Gradle
+      run: ./gradlew build -x lint

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -1,4 +1,4 @@
-name: Main Branch Build
+name: Main Build
 
 on:
   push:

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -1,0 +1,26 @@
+name: Main Branch Build
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: set up JDK 11
+      uses: actions/setup-java@v3
+      with:
+        java-version: '11'
+        distribution: 'temurin'
+        cache: gradle
+
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+    - name: Build with Gradle
+      run: ./gradlew build -x lint

--- a/.github/workflows/mishap-build.yml
+++ b/.github/workflows/mishap-build.yml
@@ -1,0 +1,27 @@
+name: Mishap Build
+
+on:
+  push:
+    branches: [ "Mishap-main" ]
+  pull_request:
+    branches: [ "Mishap-main" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: set up JDK 11
+      uses: actions/setup-java@v3
+      with:
+        java-version: '11'
+        distribution: 'temurin'
+        cache: gradle
+
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+      
+    - name: Build with Gradle
+      run: ./gradlew build -x lint

--- a/.github/workflows/smelt-build.yml
+++ b/.github/workflows/smelt-build.yml
@@ -1,0 +1,27 @@
+name: Smelt Build
+
+on:
+  push:
+    branches: [ "Smelt-main" ]
+  pull_request:
+    branches: [ "Smelt-main" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: set up JDK 11
+      uses: actions/setup-java@v3
+      with:
+        java-version: '11'
+        distribution: 'temurin'
+        cache: gradle
+
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+      
+    - name: Build with Gradle
+      run: ./gradlew build -x lint

--- a/.github/workflows/xero-build.yml
+++ b/.github/workflows/xero-build.yml
@@ -1,0 +1,27 @@
+name: Xero Build
+
+on:
+  push:
+    branches: [ "Xero-main" ]
+  pull_request:
+    branches: [ "Xero-main" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: set up JDK 11
+      uses: actions/setup-java@v3
+      with:
+        java-version: '11'
+        distribution: 'temurin'
+        cache: gradle
+
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+      
+    - name: Build with Gradle
+      run: ./gradlew build -x lint


### PR DESCRIPTION
Added simple build CI for main branch as well as separate CI scripts for team branches as well. This was done through GitHub Actions. Actions are currently set to trigger on pushes and pull requests to their respective branches. Naming scheme for each workflow file also includes the team name first before the action, therefore they can be expanded on a per team basis, as GitHub does not support subdirectories in the the workflows directory.